### PR TITLE
renaming adjoint cotangent

### DIFF
--- a/src/StateMaps/AffineFEStateMaps.jl
+++ b/src/StateMaps/AffineFEStateMaps.jl
@@ -85,8 +85,8 @@ function build_cache!(state_map::AffineFEStateMap,φh)
   _,_,_,precompute_uhd = state_map.update_opts
 
   ## Pullback cache
-  dudφ_vec = get_free_dof_values(zero(V_φ))
-  cache.plb_cache = (dudφ_vec,assem_deriv)
+  dφ_from_u_vec = get_free_dof_values(zero(V_φ))
+  cache.plb_cache = (dφ_from_u_vec,assem_deriv)
 
   ## Forward cache
   uhd = precompute_uhd ? nothing : zero(U);

--- a/src/StateMaps/FEStateMaps.jl
+++ b/src/StateMaps/FEStateMaps.jl
@@ -149,7 +149,7 @@ Compute `∂F∂u*dudφ` at `φh` and `uh` using the adjoint method. I.e., let
 and solve the adjoint problem `dRduᵀ*λ = ∂F∂uᵀ` using [`adjoint_solve!`](@ref).
 """
 function pullback(φ_to_u::AbstractFEStateMap,uh,φh,du;updated=false)
-  dudφ_vec, assem_deriv = get_plb_cache(φ_to_u)
+  dφ_from_u_vec, assem_deriv = get_plb_cache(φ_to_u)
   V_φ = get_deriv_space(φ_to_u)
 
   ## Adjoint Solve
@@ -160,11 +160,11 @@ function pullback(φ_to_u::AbstractFEStateMap,uh,φh,du;updated=false)
   λh = FEFunction(get_test_space(φ_to_u),λ)
 
   ## Compute grad
-  dudφ_vecdata = collect_cell_vector(V_φ,dRdφ(φ_to_u,uh,λh,φh))
-  assemble_vector!(dudφ_vec,assem_deriv,dudφ_vecdata)
-  rmul!(dudφ_vec, -1)
+  dφ_from_u_vecdata = collect_cell_vector(V_φ,dRdφ(φ_to_u,uh,λh,φh))
+  assemble_vector!(dφ_from_u_vec,assem_deriv,dφ_from_u_vecdata)
+  rmul!(dφ_from_u_vec, -1)
 
-  return (NoTangent(),dudφ_vec)
+  return (NoTangent(),dφ_from_u_vec)
 end
 
 function pullback(φ_to_u::AbstractFEStateMap,u::AbstractVector,φ::AbstractVector,du::AbstractVector;updated=false)

--- a/src/StateMaps/NonlinearFEStateMaps.jl
+++ b/src/StateMaps/NonlinearFEStateMaps.jl
@@ -86,8 +86,8 @@ function build_cache!(state_map::NonlinearFEStateMap,φh)
   nls, adjoint_ls = cache.solvers[1], cache.solvers[2]
 
   ## Pullback cache
-  dudφ_vec = get_free_dof_values(zero(V_φ))
-  cache.plb_cache = (dudφ_vec,assem_deriv)
+  dφ_from_u_vec = get_free_dof_values(zero(V_φ))
+  cache.plb_cache = (dφ_from_u_vec,assem_deriv)
 
   ## Forward cache
   x = zero_free_values(U)

--- a/src/StateMaps/RepeatingAffineFEStateMaps.jl
+++ b/src/StateMaps/RepeatingAffineFEStateMaps.jl
@@ -146,8 +146,8 @@ function build_cache!(state_map::RepeatingAffineFEStateMap{N},φh) where N
 
   ## Pullback cache
   uhd = zero(U0)
-  dudφ_vec = get_free_dof_values(zero(V_φ))
-  cache.plb_cache = (dudφ_vec,assem_deriv)
+  dφ_from_u_vec = get_free_dof_values(zero(V_φ))
+  cache.plb_cache = (dφ_from_u_vec,assem_deriv)
 
   ## Forward cache
   K  = assemble_matrix((u,v) -> biform(u,v,φh),assem_U0,U0,V0)


### PR DESCRIPTION
The object called dudp is really ∂F∂u*dudφ (or, keeping with the convention, the cotagent dp from the state constraint). Therefore, i propose to name it dp_from_u